### PR TITLE
bug: Avoid assigning `hostname` using `dnsmasq`

### DIFF
--- a/ignition/00-core.bu
+++ b/ignition/00-core.bu
@@ -944,11 +944,11 @@ storage:
           log-dhcp
           dhcp-authoritative
           log-async
-          dhcp-host=52:54:00:11:22:a1,master0.ocp.example.local,192.168.123.91
-          dhcp-host=52:54:00:11:22:a2,master1.ocp.example.local,192.168.123.92
-          dhcp-host=52:54:00:11:22:a3,master2.ocp.example.local,192.168.123.93
-          dhcp-host=52:54:00:11:22:a4,worker0.ocp.example.local,192.168.123.94
-          dhcp-host=52:54:00:11:22:a5,worker1.ocp.example.local,192.168.123.95
+          dhcp-host=52:54:00:11:22:a1,192.168.123.91
+          dhcp-host=52:54:00:11:22:a2,192.168.123.92
+          dhcp-host=52:54:00:11:22:a3,192.168.123.93
+          dhcp-host=52:54:00:11:22:a4,192.168.123.94
+          dhcp-host=52:54:00:11:22:a5,192.168.123.95
     - path: /opt/openshift-network-playground/pxe/Containerfile
       mode: 0644
       overwrite: true

--- a/ignition/00-core.ign
+++ b/ignition/00-core.ign
@@ -444,7 +444,7 @@
         "overwrite": true,
         "path": "/opt/openshift-network-playground/dhcp/dnsmasq.conf",
         "contents": {
-          "source": "data:,no-daemon%0Ainterface%3Dbaremetal%0Adhcp-range%3D192.168.123.2%2C192.168.123.254%2C255.255.255.0%0Aexcept-interface%3Dlo%0Abind-interfaces%0Alog-dhcp%0Adhcp-authoritative%0Alog-async%0Adhcp-host%3D52%3A54%3A00%3A11%3A22%3Aa1%2Cmaster0.ocp.example.local%2C192.168.123.91%0Adhcp-host%3D52%3A54%3A00%3A11%3A22%3Aa2%2Cmaster1.ocp.example.local%2C192.168.123.92%0Adhcp-host%3D52%3A54%3A00%3A11%3A22%3Aa3%2Cmaster2.ocp.example.local%2C192.168.123.93%0Adhcp-host%3D52%3A54%3A00%3A11%3A22%3Aa4%2Cworker0.ocp.example.local%2C192.168.123.94%0Adhcp-host%3D52%3A54%3A00%3A11%3A22%3Aa5%2Cworker1.ocp.example.local%2C192.168.123.95%0A"
+          "source": "data:,no-daemon%0Ainterface%3Dbaremetal%0Adhcp-range%3D192.168.123.2%2C192.168.123.254%2C255.255.255.0%0Aexcept-interface%3Dlo%0Abind-interfaces%0Alog-dhcp%0Adhcp-authoritative%0Alog-async%0Adhcp-host%3D52%3A54%3A00%3A11%3A22%3Aa1%2C192.168.123.91%0Adhcp-host%3D52%3A54%3A00%3A11%3A22%3Aa2%2C192.168.123.92%0Adhcp-host%3D52%3A54%3A00%3A11%3A22%3Aa3%2C192.168.123.93%0Adhcp-host%3D52%3A54%3A00%3A11%3A22%3Aa4%2C192.168.123.94%0Adhcp-host%3D52%3A54%3A00%3A11%3A22%3Aa5%2C192.168.123.95%0A"
         },
         "mode": 420
       },


### PR DESCRIPTION
- Remove `hostname` from `dhcp-host=`

Fixes: #39